### PR TITLE
Заменил 3.1415 на TxPi.

### DIFF
--- a/monkey.cpp
+++ b/monkey.cpp
@@ -44,7 +44,7 @@ int main()
 
 void planeDraw(int x, int y, double zoom, int countWindows, int countMotors, bool rearMotor, int chassisAngle)
 {
-    double cAngle = chassisAngle*txPi/180;
+    double cAngle = chassisAngle*M_PI/180;
     txSetColor (TX_BLACK, 2);
     txSetFillColor (TX_YELLOW);
 

--- a/monkey.cpp
+++ b/monkey.cpp
@@ -44,7 +44,7 @@ int main()
 
 void planeDraw(int x, int y, double zoom, int countWindows, int countMotors, bool rearMotor, int chassisAngle)
 {
-    double cAngle = chassisAngle*3.1415926/180;
+    double cAngle = chassisAngle*txPi/180;
     txSetColor (TX_BLACK, 2);
     txSetFillColor (TX_YELLOW);
 


### PR DESCRIPTION
Возможно есть ошибки! Если что поправте.
Даниил, идея правильная (число Pi хранится в C++ с более высокой точностью, чем 4 или даже 8 знаков после запятой), вот только txPi - это не 3.1415926. Можешь вывести на экран с помощью printf. Нормальное число Пи хранится в математической библиотеке. Найдешь - молодец)